### PR TITLE
Create missing $BUILD_DIR/.heroku

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -18,6 +18,7 @@ if [ -d $TARGET_DIR/gettext ]; then
 fi
 
 echo "-----> Installing gettext..."
+mkdir -p $BUILD_DIR/.heroku
 curl --silent --max-time 60 --location "$GETTEXT_TARBALL" | tar xz -C "$BUILD_DIR/.heroku"
 
 # display version in a nice way


### PR DESCRIPTION
Try to solve issue with missing `$BUILD_DIR/.heroku` path when used as the first buildpack.

When used together with `heroku/python` buildpack to build a Django-based project, it has to be set as the first buildpack in order to handle correctly the Django's `compilemessages` command.

The issue is related to the fact at that moment no others buildpacks have already created the `.heroku` folder so the buildpack fails to install `gettext`.

Merging this fixes #6 and should solve also #3 (and #5).
